### PR TITLE
refactor(models): align device parsing with DeviceResponseDto + nested state/location models

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,90 @@ To use this library, you need to:
 
 - `httpx`: A fully featured HTTP client for Python 3.
 
+## Testing
+
+The project includes integration tests for the client in `tests/test_client.py`.
+These tests call the real Themo API (no mocks). You can run them with either a bearer token or username/password credentials.
+
+### Install test dependencies
+
+```powershell
+python -m pip install -U pytest httpx
+```
+
+### Set environment variables
+
+You can authenticate test requests in either of these ways:
+- Bearer token (`THEMO_TOKEN`) for read-only API calls
+- Username/password (`THEMO_USERNAME`, `THEMO_PASSWORD`) for the `authenticate()` integration test
+
+PowerShell (Windows):
+
+Bearer token (for token-based tests):
+
+```powershell
+$env:THEMO_TOKEN = "YOUR_BEARER_TOKEN"
+```
+
+Username/password (for `authenticate()` test):
+
+```powershell
+$env:THEMO_USERNAME = "your-email@example.com"
+$env:THEMO_PASSWORD = "your-password"
+```
+
+Optional (enables device-specific tests):
+
+```powershell
+$env:THEMO_ENV_ID = "123"
+$env:THEMO_DEVICE_ID = "456"
+```
+
+Git Bash:
+
+Bearer token (for token-based tests):
+
+```bash
+export THEMO_TOKEN="YOUR_BEARER_TOKEN"
+```
+
+Username/password (for `authenticate()` test):
+
+```bash
+export THEMO_USERNAME="your-email@example.com"
+export THEMO_PASSWORD="your-password"
+```
+
+Optional (enables device-specific tests):
+
+```bash
+export THEMO_ENV_ID="123"
+export THEMO_DEVICE_ID="456"
+```
+
+### Run tests
+
+Use `python -m pytest` instead of `pytest` on Windows to avoid PATH / interpreter mismatch issues.
+
+PowerShell:
+
+```powershell
+python -m pytest -q tests\\test_client.py -s
+```
+
+Git Bash:
+
+```bash
+python -m pytest -q tests/test_client.py -s
+```
+
+Notes:
+- If `THEMO_TOKEN` is not set, token-based integration tests will be skipped.
+- If `THEMO_USERNAME` and `THEMO_PASSWORD` are not set, the `authenticate()` integration test will be skipped.
+- If `THEMO_ENV_ID` and `THEMO_DEVICE_ID` are not set, device-specific integration tests will be skipped.
+- Current integration tests are read-only and do not send control commands.
+
+
 ## Contributions
 
 Contributions to the `pythemo` repository are welcome. Please ensure that you follow the coding conventions and write tests for any new features or changes.

--- a/pythemo/models.py
+++ b/pythemo/models.py
@@ -1,24 +1,163 @@
-"""Module containing the Device class to represent a Themo device and its state."""
+"""Module containing device models for Themo API payloads."""
 
+from enum import IntEnum
 from typing import TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     from pythemo.client import ThemoClient
 
 
-class Device:
-    """A class to represent a Themo device and manage its state and attributes."""
+class LockState(IntEnum):
+    """Lock state values returned by the Themo API."""
 
-    STATE_ATTRIBUTES: ClassVar[dict[str, str]] = {
+    OFF = 0
+    ON = 1
+    HARD_LOCK = 2
+
+
+class LocationResponse:
+    """Represents top-level device location payload."""
+
+    ATTRIBUTES: ClassVar[dict[str, str]] = {
+        "country_short": "CountryShort",
+        "lat": "Lat",
+        "lng": "Lng",
+        "raw_offset": "RawOffset",
+        "weather_group_id": "WeatherGroupId",
+    }
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self.country_short: str | None = None
+        self.lat: float | None = None
+        self.lng: float | None = None
+        self.raw_offset: int | None = None
+        self.weather_group_id: int | None = None
+        self.update_attributes(data or {})
+
+    def update_attributes(self, data: dict[str, Any]) -> None:
+        """Update location attributes from API payload."""
+        for attr, key in self.ATTRIBUTES.items():
+            setattr(self, attr, data.get(key))
+
+
+class DeviceParameters:
+    """Represents nested device parameter flags in state."""
+
+    ATTRIBUTES: ClassVar[dict[str, str]] = {
+        "is_price_switch": "IsPriceSwitch",
+        "is_air": "IsAir",
+        "is_floor": "IsFloor",
+        "is_combi": "IsCombi",
+    }
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self.is_price_switch: bool | None = None
+        self.is_air: bool | None = None
+        self.is_floor: bool | None = None
+        self.is_combi: bool | None = None
+        self.update_attributes(data or {})
+
+    def update_attributes(self, data: dict[str, Any]) -> None:
+        """Update device parameter attributes from API payload."""
+        for attr, key in self.ATTRIBUTES.items():
+            value = data.get(key)
+            if value is not None:
+                value = bool(value)
+            setattr(self, attr, value)
+
+
+class DeviceState:
+    """Represents the nested device state payload."""
+
+    BOOLEAN_INT_ATTRIBUTES: ClassVar[set[str]] = {"frost_protection", "lights"}
+
+    ATTRIBUTES: ClassVar[dict[str, str]] = {
+        "connection_state": "CS",
+        "device_parameters": "DeviceParameters",
         "floor_temperature": "FloorT",
+        "frost_protection": "FTS",
+        "frost_temperature": "FT",
         "info": "Info",
+        "is_external_temp_ok": "IsExternalTempOk",
+        "load_state": "LS",
         "lights": "Lights",
+        "lock": "Lock",
         "manual_temperature": "MT",
         "max_power": "MP",
         "mode": "Mode",
+        "outside_temperature": "OT",
         "power": "Power",
         "room_temperature": "RT",
+        "state_time": "Time",
+        "temperature_sensor": "TmpSns",
+        "timer_boost": "TB",
+        "failsafe_temperature": "ST",
         "sw_version": "SW",
+    }
+
+    def __init__(self, data: dict[str, Any] | None = None) -> None:
+        self.connection_state: bool | None = None
+        self.device_parameters: DeviceParameters | None = None
+        self.floor_temperature: float | None = None
+        self.frost_protection: bool | None = None
+        self.frost_temperature: float | None = None
+        self.info: float | None = None
+        self.is_external_temp_ok: bool | None = None
+        self.load_state: int | None = None
+        self.lights: bool | None = None
+        self.lock: LockState | int | None = None
+        self.manual_temperature: float | None = None
+        self.max_power: float | None = None
+        self.mode: str | None = None
+        self.outside_temperature: float | None = None
+        self.power: bool | None = None
+        self.room_temperature: float | None = None
+        self.state_time: str | None = None
+        self.temperature_sensor: str | None = None
+        self.timer_boost: int | None = None
+        self.failsafe_temperature: float | None = None
+        self.sw_version: str | None = None
+        self.update_attributes(data or {})
+
+    def update_attributes(self, data: dict[str, Any]) -> None:
+        """Update state attributes from API payload."""
+        for attr, key in self.ATTRIBUTES.items():
+            value = data.get(key)
+            if attr in self.BOOLEAN_INT_ATTRIBUTES and value is not None:
+                value = bool(value)
+            if attr == "lock" and value is not None:
+                try:
+                    value = LockState(value)
+                except ValueError:
+                    pass
+            if attr == "device_parameters" and isinstance(value, dict):
+                if self.device_parameters is None:
+                    self.device_parameters = DeviceParameters(value)
+                else:
+                    self.device_parameters.update_attributes(value)
+                value = self.device_parameters
+            elif attr == "device_parameters":
+                value = None
+            setattr(self, attr, value)
+
+
+class Device:
+    """Represents a Themo device with top-level metadata and nested state."""
+
+    ATTRIBUTES: ClassVar[dict[str, str]] = {
+        "id": "Id",
+        "name": "Name",
+        "device_id": "DeviceId",
+        "device_auth": "DeviceAuth",
+        "client_id": "ClientId",
+        "location": "Location",
+        "environment_id": "EnvironmentId",
+        "environment_name": "EnvironmentName",
+        "tags": "Tags",
+        "active_schedule_id": "ActiveScheduleId",
+        "temperature_schedule": "TemperatureSchedule",
+        "sw_version": "SW",
+        "state": "State",
     }
 
     def __init__(
@@ -34,30 +173,48 @@ class Device:
 
         self.name: str | None = None
         self.device_id: str | None = None
+        self.device_auth: str | None = None
+        self.client_id: int | None = None
+        self.location: LocationResponse | None = None
+        self.environment_name: str | None = None
+        self.tags: str | None = None
+        self.active_schedule_id: int | None = None
+        self.temperature_schedule: str | None = None
+        self.sw_version: str | None = None
 
         self.active_schedule: str | None = None
         self.available_schedules: list[str] = []
 
-        self.floor_temperature: float | None = None
-        self.info: str | None = None
-        self.lights: bool | None = None
-        self.manual_temperature: float | None = None
-        self.max_power: float | None = None
-        self.mode: str | None = None
-        self.power: float | None = None
-        self.room_temperature: float | None = None
+        self.state: DeviceState = DeviceState()
 
     def __repr__(self) -> str:
         """Return a string representation of the Device instance."""
-        return f"<Themo(id={self.id!r}, name={self.name!r}>"
+        return f"<Themo(id={self.id!r}, name={self.name!r})>"
 
     def update_attributes(self, data: dict[str, Any]) -> None:
-        """Update device attributes."""
-        self.name = data.get("Name")
-        self.device_id = data.get("DeviceId")
+        """Update top-level device attributes and nested state."""
+        for attr, key in self.ATTRIBUTES.items():
+            value = data.get(key)
 
-        state_data: dict[str, Any] = data.get("State", {})
-        self._update_state_attributes(state_data)
+            if attr in {"id", "environment_id"} and value is not None:
+                value = str(value)
+
+            if attr == "location" and isinstance(value, dict):
+                if self.location is None:
+                    self.location = LocationResponse(value)
+                else:
+                    self.location.update_attributes(value)
+                value = self.location
+            elif attr == "location":
+                value = None
+
+            if attr == "state" and isinstance(value, dict):
+                self.state.update_attributes(value)
+                value = self.state
+            elif attr == "state":
+                value = self.state
+
+            setattr(self, attr, value)
 
     async def update_state(self) -> None:
         """Primary method to update the device state."""
@@ -88,17 +245,10 @@ class Device:
     def _update_schedules(self, schedules_data: list[dict[str, Any]]) -> None:
         """Update device schedules based on the provided data."""
         self.available_schedules = [schedule["Name"] for schedule in schedules_data]
+        self.active_schedule = None
         for schedule in schedules_data:
             if schedule["Active"]:
                 self.active_schedule = schedule["Name"]
-
-    def _update_state_attributes(self, state_data: dict[str, Any]) -> None:
-        """Update device state attributes."""
-        for attr, key in self.STATE_ATTRIBUTES.items():
-            value = state_data.get(key)
-            if attr == "lights":
-                value = bool(value)
-            setattr(self, attr, value)
 
     async def set_lights(self, state: bool) -> None:
         """Set the lights state."""
@@ -107,7 +257,7 @@ class Device:
             self.id,
             state,
         )
-        self.lights = state
+        self.state.lights = state
 
     async def set_manual_temperature(self, temperature: int) -> None:
         """Set the manual temperature."""
@@ -116,7 +266,7 @@ class Device:
             self.id,
             temperature,
         )
-        self.manual_temperature = temperature
+        self.state.manual_temperature = temperature
 
     async def set_mode(self, mode: str) -> None:
         """Set the device mode."""
@@ -125,7 +275,7 @@ class Device:
             self.id,
             mode,
         )
-        self.mode = mode
+        self.state.mode = mode
 
     async def set_active_schedule(self, schedule_name: str) -> None:
         """Switch to a different schedule."""
@@ -133,7 +283,6 @@ class Device:
             msg = f"Invalid schedule name: {schedule_name}"
             raise ValueError(msg)
 
-        # Find the schedule ID for the given name
         schedules = await self._client.get_device_schedules(
             self.environment_id,
             self.id,
@@ -145,11 +294,10 @@ class Device:
                 schedule_id = schedule["Id"]
                 break
 
-        if not schedule_id:
+        if schedule_id is None:
             msg = f"Could not find ID for schedule: {schedule_name}"
             raise ValueError(msg)
 
-        # Update the schedule to be active
         await self._client.update_schedule(
             self.environment_id,
             self.id,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,318 @@
+import asyncio
+import os
+
+import httpx
+import pytest
+
+from pythemo.client import ThemoClient
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        pytest.skip(f"Missing environment variable: {name}")
+    return value
+
+
+def _token() -> str:
+    return _env("THEMO_TOKEN")
+
+
+def test_integration_get_environments() -> None:
+    async def _test() -> None:
+        http_client = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {_token()}"},
+            timeout=30.0,
+        )
+        client = ThemoClient(username="", password="", client=http_client)
+        try:
+            environments = await client.get_environments()
+            assert isinstance(environments, list)
+            assert environments, "No environments returned"
+            assert all("Id" in env for env in environments)
+        finally:
+            await http_client.aclose()
+
+    _run(_test())
+
+
+def test_integration_get_all_devices() -> None:
+    async def _test() -> None:
+        http_client = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {_token()}"},
+            timeout=30.0,
+        )
+        client = ThemoClient(username="", password="", client=http_client)
+        try:
+            devices = await client.get_all_devices()
+            assert isinstance(devices, list)
+            assert devices, "No devices returned"
+
+            device = devices[0]
+            assert device.id
+            assert device.environment_id
+            assert hasattr(device, "state")
+            assert device.state is not None
+            assert hasattr(device.state, "ATTRIBUTES")
+
+            # Ensure all mapped state attrs exist on the DeviceState instance
+            for attr in device.state.ATTRIBUTES:
+                assert hasattr(device.state, attr), f"Missing mapped state attribute: {attr}"
+        finally:
+            await http_client.aclose()
+
+    _run(_test())
+
+
+def test_integration_get_specific_device_data() -> None:
+    env_id = os.getenv("THEMO_ENV_ID")
+    device_id = os.getenv("THEMO_DEVICE_ID")
+    if not env_id or not device_id:
+        pytest.skip("Set THEMO_ENV_ID and THEMO_DEVICE_ID to run this test")
+
+    async def _test() -> None:
+        http_client = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {_token()}"},
+            timeout=30.0,
+        )
+        client = ThemoClient(username="", password="", client=http_client)
+        try:
+            payload = await client.get_device_data(env_id, device_id)
+            assert isinstance(payload, dict)
+            assert str(payload.get("Id")) == str(device_id)
+            assert "State" in payload
+            assert isinstance(payload["State"], dict)
+        finally:
+            await http_client.aclose()
+
+    _run(_test())
+
+
+def test_integration_get_device_model_and_schedules() -> None:
+    env_id = os.getenv("THEMO_ENV_ID")
+    device_id = os.getenv("THEMO_DEVICE_ID")
+    if not env_id or not device_id:
+        pytest.skip("Set THEMO_ENV_ID and THEMO_DEVICE_ID to run this test")
+
+    async def _test() -> None:
+        http_client = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {_token()}"},
+            timeout=30.0,
+        )
+        client = ThemoClient(username="", password="", client=http_client)
+        try:
+            device = await client.get_device(env_id, device_id)
+            assert device.id == str(device_id)
+            assert device.environment_id == str(env_id)
+            assert isinstance(device.available_schedules, list)
+            assert device.state is not None
+        finally:
+            await http_client.aclose()
+
+    _run(_test())
+
+
+def test_integration_device_state_mapping_matches_raw_payload() -> None:
+    env_id = os.getenv("THEMO_ENV_ID")
+    device_id = os.getenv("THEMO_DEVICE_ID")
+    if not env_id or not device_id:
+        pytest.skip("Set THEMO_ENV_ID and THEMO_DEVICE_ID to run this test")
+
+    async def _test() -> None:
+        http_client = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {_token()}"},
+            timeout=30.0,
+        )
+        client = ThemoClient(username="", password="", client=http_client)
+        try:
+            request_path = f"api/environments/{env_id}/devices/{device_id}"
+            print("RAW REQUEST:", {"method": "GET", "path": request_path, "params": {"state": True}})
+
+            raw_payload = await client.get_device_data(env_id, device_id)
+            print("RAW RESPONSE:", raw_payload)
+
+            device = await client.get_device(env_id, device_id)
+
+            raw_state = raw_payload.get("State")
+            assert isinstance(raw_state, dict), "Raw payload missing State dict"
+
+            failures: list[str] = []
+
+            def _log_check(label: str, expected: object, actual: object) -> bool:
+                ok = actual == expected
+                print(f"{'OK' if ok else 'FAIL'} {label}: expected={expected!r}, actual={actual!r}")
+                return ok
+
+            top_attr_map = device.ATTRIBUTES
+            mapped_top_keys = set(top_attr_map.values())
+            unmapped_top_keys = sorted(set(raw_payload) - mapped_top_keys)
+            print(
+                f"{'OK' if not unmapped_top_keys else 'FAIL'} top-level mapping coverage: "
+                f"unmapped={unmapped_top_keys!r}",
+            )
+            if unmapped_top_keys:
+                failures.append(f"Unmapped raw top-level keys: {unmapped_top_keys}")
+
+            for attr, raw_key in top_attr_map.items():
+                if attr == "state":
+                    continue
+
+                raw_value = raw_payload.get(raw_key)
+                model_value = getattr(device, attr)
+
+                if attr in {"id", "environment_id"} and raw_value is not None:
+                    raw_value = str(raw_value)
+
+                if attr == "location":
+                    if raw_value is None:
+                        if not _log_check("device.location", None, model_value):
+                            failures.append(f"device.location: expected None, got {model_value!r}")
+                        continue
+
+                    raw_is_dict = isinstance(raw_value, dict)
+                    print(
+                        f"{'OK' if raw_is_dict else 'FAIL'} device.location raw type: "
+                        f"expected=dict, actual={type(raw_value).__name__}",
+                    )
+                    if not raw_is_dict:
+                        failures.append("Top-level Location must be dict when present")
+                        continue
+                    if not _log_check("device.location present", True, model_value is not None):
+                        failures.append("Mapped location model missing")
+                        continue
+
+                    location_attr_map = model_value.ATTRIBUTES
+                    mapped_location_keys = set(location_attr_map.values())
+                    unmapped_location_keys = sorted(set(raw_value) - mapped_location_keys)
+                    print(
+                        f"{'OK' if not unmapped_location_keys else 'FAIL'} location mapping coverage: "
+                        f"unmapped={unmapped_location_keys!r}",
+                    )
+                    if unmapped_location_keys:
+                        failures.append(f"Unmapped Location keys: {unmapped_location_keys}")
+
+                    for location_attr, location_raw_key in location_attr_map.items():
+                        expected_loc = raw_value.get(location_raw_key)
+                        actual_loc = getattr(model_value, location_attr)
+                        if not _log_check(
+                            f"device.location.{location_attr}",
+                            expected_loc,
+                            actual_loc,
+                        ):
+                            failures.append(
+                                f"device.location.{location_attr}: expected {expected_loc!r}, got {actual_loc!r}",
+                            )
+                    continue
+
+                if not _log_check(f"device.{attr}", raw_value, model_value):
+                    failures.append(f"device.{attr}: expected {raw_value!r}, got {model_value!r}")
+
+            state_attr_map = device.state.ATTRIBUTES
+            mapped_raw_keys = set(state_attr_map.values())
+            unmapped_state_keys = sorted(set(raw_state) - mapped_raw_keys)
+            print(
+                f"{'OK' if not unmapped_state_keys else 'FAIL'} state mapping coverage: "
+                f"unmapped={unmapped_state_keys!r}",
+            )
+            if unmapped_state_keys:
+                failures.append(f"Unmapped raw State keys: {unmapped_state_keys}")
+
+            for attr, raw_key in state_attr_map.items():
+                raw_value = raw_state.get(raw_key)
+                model_value = getattr(device.state, attr)
+
+                if attr == "device_parameters":
+                    if raw_value is None:
+                        if not _log_check("state.device_parameters", None, model_value):
+                            failures.append(
+                                f"state.device_parameters: expected None, got {model_value!r}",
+                            )
+                        continue
+
+                    raw_is_dict = isinstance(raw_value, dict)
+                    print(
+                        f"{'OK' if raw_is_dict else 'FAIL'} state.device_parameters raw type: "
+                        f"expected=dict, actual={type(raw_value).__name__}",
+                    )
+                    if not raw_is_dict:
+                        failures.append("State.DeviceParameters must be a dict when present")
+                        continue
+                    if not _log_check("state.device_parameters present", True, model_value is not None):
+                        failures.append("Mapped device_parameters model missing")
+                        continue
+
+                    param_attr_map = model_value.ATTRIBUTES
+                    mapped_param_keys = set(param_attr_map.values())
+                    unmapped_param_keys = sorted(set(raw_value) - mapped_param_keys)
+                    print(
+                        f"{'OK' if not unmapped_param_keys else 'FAIL'} device_parameters mapping coverage: "
+                        f"unmapped={unmapped_param_keys!r}",
+                    )
+                    if unmapped_param_keys:
+                        failures.append(f"Unmapped DeviceParameters keys: {unmapped_param_keys}")
+
+                    for param_attr, param_raw_key in param_attr_map.items():
+                        expected_param_value = raw_value.get(param_raw_key)
+                        if expected_param_value is not None:
+                            expected_param_value = bool(expected_param_value)
+                        actual_param_value = getattr(model_value, param_attr)
+                        if not _log_check(
+                            f"state.device_parameters.{param_attr}",
+                            expected_param_value,
+                            actual_param_value,
+                        ):
+                            failures.append(
+                                f"state.device_parameters.{param_attr}: expected {expected_param_value!r}, got {actual_param_value!r}",
+                            )
+                    continue
+
+                if attr in device.state.BOOLEAN_INT_ATTRIBUTES and raw_value is not None:
+                    expected_bool = bool(raw_value)
+                    if not _log_check(f"state.{attr}", expected_bool, model_value):
+                        failures.append(f"state.{attr}: expected {expected_bool!r}, got {model_value!r}")
+                    is_bool = isinstance(model_value, bool)
+                    print(
+                        f"{'OK' if is_bool else 'FAIL'} state.{attr} type: "
+                        f"expected=bool, actual={type(model_value).__name__}",
+                    )
+                    if not is_bool:
+                        failures.append(
+                            f"state.{attr} type mismatch: expected bool, got {type(model_value).__name__}",
+                        )
+                    continue
+
+                if not _log_check(f"state.{attr}", raw_value, model_value):
+                    failures.append(f"state.{attr}: expected {raw_value!r}, got {model_value!r}")
+
+            assert not failures, "Device mapping mismatches:\n" + "\n".join(failures)
+        finally:
+            await http_client.aclose()
+
+    _run(_test())
+
+
+def test_integration_authenticate_with_username_password() -> None:
+    username = os.getenv("THEMO_USERNAME")
+    password = os.getenv("THEMO_PASSWORD")
+    if not username or not password:
+        pytest.skip("Set THEMO_USERNAME and THEMO_PASSWORD to run this test")
+
+    async def _test() -> None:
+        http_client = httpx.AsyncClient(timeout=30.0)
+        client = ThemoClient(username=username, password=password, client=http_client)
+        try:
+            await client.authenticate()
+            auth_header = http_client.headers.get("Authorization", "")
+            assert auth_header.startswith("Bearer ")
+            assert client._environments is not None
+            assert isinstance(client._environments, list)
+        finally:
+            await http_client.aclose()
+
+    _run(_test())
+
+


### PR DESCRIPTION
## Summary
This PR refactors device parsing to mirror the API response structure and strengthens integration coverage for mapping correctness.

## What Changed

### 1. Refactored Models To Match API Shape
- Added structured models in `pythemo/models.py`:
  - `Device`
  - `DeviceState`
  - `DeviceParameters`
  - `LocationResponse`
  - `LockState` enum
- Switched from flattened device state fields to nested `device.state.*`.
- Added mapping tables (`ATTRIBUTES`) for each model and parse/update loops driven by those mappings.
- Added top-level `DeviceResponseDto` mapping on `Device`:
  - `Id`, `Name`, `DeviceId`, `DeviceAuth`, `ClientId`, `Location`,
  - `EnvironmentId`, `EnvironmentName`, `Tags`,
  - `ActiveScheduleId`, `TemperatureSchedule`, `SW`, `State`.
- Added nested `LocationResponseDto` mapping on `device.location`.
- Added nested `DeviceStateDto` mapping on `device.state`.
- Added nested `DeviceParameters` mapping on `device.state.device_parameters`.

### 2. State/Value Handling
- Added boolean normalization for `0/1` state flags:
  - `lights` (`Lights`)
  - `frost_protection` (`FTS`)
- Added `LockState` enum parsing for `Lock` with tolerant fallback:
  - known values -> enum
  - unknown values -> preserved raw integer

### 3. Integration Test Expansion
- Added `tests/test_client.py` integration mapping test to validate:
  - top-level `Device` mapping
  - nested `LocationResponse` mapping
  - nested `DeviceState` mapping
  - nested `DeviceParameters` mapping
- Added mapping coverage checks:
  - fail on unmapped raw top-level keys
  - fail on unmapped raw `State` keys
  - fail on unmapped raw `DeviceParameters` keys
- Added explicit comparison logs for all checks (`OK`/`FAIL`).
- Added raw request/response logging in the mapping test:
  - `RAW REQUEST`
  - `RAW RESPONSE`

## Files Updated
- `pythemo/models.py`
- `tests/test_client.py`
-  `README.md`

## Notes
- This is a model-structure change: consumers should now read state from `device.state` (instead of expecting flattened state fields directly on `Device`).
- The integration mapping test is verbose by design for debugging parse/mapping discrepancies.
